### PR TITLE
Add nightly GitHub Actions workflow for payment API pentest

### DIFF
--- a/.github/workflows/nightly-pentest.yml
+++ b/.github/workflows/nightly-pentest.yml
@@ -1,0 +1,88 @@
+name: Nightly Payment API Pentest
+
+on:
+  schedule:
+    - cron: '0 2 * * *'  # 02:00 UTC every night
+  workflow_dispatch:      # allow manual trigger from GitHub UI
+    inputs:
+      groups:
+        description: 'Test tag groups to run (e.g. auth,injection). Leave blank for all.'
+        required: false
+        default: ''
+      target_env:
+        description: 'Target environment (staging or sandbox)'
+        required: false
+        default: 'staging'
+
+jobs:
+  pentest:
+    name: Run Pentest Suite
+    runs-on: ubuntu-latest
+    environment: pentest-staging  # GitHub environment with secrets + optional approval gate
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Run pentest suite
+        env:
+          PENTEST_BASE_URL:       ${{ secrets.PENTEST_BASE_URL }}
+          PENTEST_USER_TOKEN:     ${{ secrets.PENTEST_USER_TOKEN }}
+          PENTEST_ADMIN_TOKEN:    ${{ secrets.PENTEST_ADMIN_TOKEN }}
+          PENTEST_API_KEY:        ${{ secrets.PENTEST_API_KEY }}
+          PENTEST_TEST_ACCOUNT_ID: ${{ secrets.PENTEST_TEST_ACCOUNT_ID }}
+          TARGET_ENV: ${{ github.event.inputs.target_env || 'staging' }}
+        run: |
+          GROUPS="${{ github.event.inputs.groups }}"
+          if [ -n "$GROUPS" ]; then
+            mvn test -Dgroups="$GROUPS" --no-transfer-progress
+          else
+            mvn test -DexcludedGroups=destructive --no-transfer-progress
+          fi
+
+      - name: Upload Allure results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: allure-results-${{ github.run_number }}
+          path: target/allure-results/
+          retention-days: 30
+
+      - name: Upload findings summary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pentest-summary-${{ github.run_number }}
+          path: target/pentest-reports/
+          retention-days: 30
+
+      - name: Upload Surefire reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: surefire-reports-${{ github.run_number }}
+          path: target/surefire-reports/
+          retention-days: 30
+
+      - name: Post summary to job output
+        if: always()
+        run: |
+          if [ -f target/pentest-reports/summary.txt ]; then
+            echo "## Pentest Summary" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            cat target/pentest-reports/summary.txt >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Fail job if CRITICAL tests failed
+        if: failure()
+        run: |
+          echo "One or more pentest tests failed. Review the findings summary artifact."
+          exit 1


### PR DESCRIPTION
Schedules the pentest suite to run at 02:00 UTC daily, uploads Allure results, findings summary, and Surefire reports as artifacts. Supports manual dispatch with tag group and environment inputs.