### PR TITLE
Fix nightly build: run both Payment API and Stripe pentest suites

### DIFF
--- a/.github/workflows/nightly-pentest.yml
+++ b/.github/workflows/nightly-pentest.yml
@@ -34,7 +34,7 @@ jobs:
           distribution: 'temurin'
           cache: maven
 
-      - name: Run pentest suite
+      - name: Run Payment API pentest suite
         env:
           PENTEST_BASE_URL:        ${{ secrets.PENTEST_BASE_URL }}
           PENTEST_USER_TOKEN:      ${{ secrets.PENTEST_USER_TOKEN }}
@@ -49,10 +49,25 @@ jobs:
         run: |
           GROUPS="${{ github.event.inputs.groups }}"
           if [ -n "$GROUPS" ]; then
-            mvn test -Dgroups="$GROUPS" --no-transfer-progress
+            mvn test -Dgroups="$GROUPS" -DexcludedGroups=stripe --no-transfer-progress
           else
             mvn test -DexcludedGroups=destructive,stripe --no-transfer-progress
           fi
+
+      - name: Run Stripe pentest suite
+        if: always()   # run even if payment API step has failures
+        env:
+          PENTEST_BASE_URL:        https://api.stripe.com
+          PENTEST_API_KEY:         ${{ secrets.STRIPE_API_KEY }}
+          PENTEST_USER_TOKEN:      ${{ secrets.STRIPE_API_KEY }}
+          PENTEST_TEST_ACCOUNT_ID: ${{ secrets.STRIPE_TEST_ACCOUNT_ID }}
+          TARGET_ENV:              sandbox
+          # Issue creation reuses the same flag — Stripe findings go to the same repo
+          PENTEST_CREATE_ISSUES:   'true'
+          GITHUB_TOKEN:            ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPO:             ${{ github.repository }}
+        run: |
+          mvn test -Dgroups=stripe -DexcludedGroups=destructive --no-transfer-progress
 
       - name: Upload Allure results
         if: always()

--- a/.github/workflows/nightly-pentest.yml
+++ b/.github/workflows/nightly-pentest.yml
@@ -51,7 +51,7 @@ jobs:
           if [ -n "$GROUPS" ]; then
             mvn test -Dgroups="$GROUPS" --no-transfer-progress
           else
-            mvn test -DexcludedGroups=destructive --no-transfer-progress
+            mvn test -DexcludedGroups=destructive,stripe --no-transfer-progress
           fi
 
       - name: Upload Allure results

--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,7 @@
                 <configuration>
                     <includes>
                         <include>**/*Test.java</include>
+                        <include>**/*Suite.java</include>
                     </includes>
                     <systemPropertyVariables>
                         <allure.results.directory>${project.build.directory}/allure-results</allure.results.directory>

--- a/src/test/java/com/example/pentest/stripe/accesscontrol/BolaIdorPaymentTest.java
+++ b/src/test/java/com/example/pentest/stripe/accesscontrol/BolaIdorPaymentTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Tag("bola")
+@Tag("stripe")
 @DisplayName("Broken Object Level Authorization (IDOR) Tests")
 class BolaIdorPaymentTest extends PentestBase {
 

--- a/src/test/java/com/example/pentest/stripe/accesscontrol/MassAssignmentPaymentTest.java
+++ b/src/test/java/com/example/pentest/stripe/accesscontrol/MassAssignmentPaymentTest.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Tag("bola")
+@Tag("stripe")
 @DisplayName("Mass Assignment and Privilege Escalation Tests")
 class MassAssignmentPaymentTest extends PentestBase {
 

--- a/src/test/java/com/example/pentest/stripe/auth/AuthStripeApiKeyTest.java
+++ b/src/test/java/com/example/pentest/stripe/auth/AuthStripeApiKeyTest.java
@@ -12,6 +12,7 @@ import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Tag("auth")
+@Tag("stripe")
 @DisplayName("Stripe API Key Authentication Tests")
 class AuthStripeApiKeyTest extends PentestBase {
 

--- a/src/test/java/com/example/pentest/stripe/exposure/ExposurePanInResponseTest.java
+++ b/src/test/java/com/example/pentest/stripe/exposure/ExposurePanInResponseTest.java
@@ -16,6 +16,7 @@ import java.util.regex.Pattern;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Tag("exposure")
+@Tag("stripe")
 @DisplayName("Sensitive Data Exposure Tests (PAN, CVV, Security Headers)")
 class ExposurePanInResponseTest extends PentestBase {
 

--- a/src/test/java/com/example/pentest/stripe/injection/InjectionSqlPaymentTest.java
+++ b/src/test/java/com/example/pentest/stripe/injection/InjectionSqlPaymentTest.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Tag("injection")
+@Tag("stripe")
 @DisplayName("Injection Attack Tests (SQL, Command, Metadata)")
 class InjectionSqlPaymentTest extends PentestBase {
 

--- a/src/test/java/com/example/pentest/stripe/injection/SsrfPaymentCallbackTest.java
+++ b/src/test/java/com/example/pentest/stripe/injection/SsrfPaymentCallbackTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 @Tag("injection")
+@Tag("stripe")
 @DisplayName("Server-Side Request Forgery (SSRF) — Webhook URL Tests")
 class SsrfPaymentCallbackTest extends PentestBase {
 

--- a/src/test/java/com/example/pentest/stripe/ratelimit/RateLimitPaymentSubmissionTest.java
+++ b/src/test/java/com/example/pentest/stripe/ratelimit/RateLimitPaymentSubmissionTest.java
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeUnit;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Tag("ratelimit")
+@Tag("stripe")
 @DisplayName("Rate Limiting and Abuse Control Tests")
 class RateLimitPaymentSubmissionTest extends PentestBase {
 


### PR DESCRIPTION
## Summary

Follow-up fixes and improvements after merging #8 (spec-driven pentest suite).

### Fix 1 — `PentestSuite` not running in nightly build

`pom.xml` Surefire only matched `**/*Test.java` — `PentestSuite` was silently skipped on every `mvn test` invocation.

**Fix:** added `**/*Suite.java` to the Surefire `<includes>` block.

### Fix 2 — Stripe tests running against the wrong target

Stripe tests hit `api.stripe.com` with a Stripe API key, but the nightly workflow pointed everything at the Payment API. Running them in the same step fails against the wrong base URL with invalid credentials.

**Fix:** added `@Tag("stripe")` to all 7 Stripe test classes so they can be included/excluded independently.

### Fix 3 — Run both suites in the nightly workflow

Since both suites share config key names (`PENTEST_BASE_URL`, `PENTEST_API_KEY`, etc.) they cannot share a single `mvn test` invocation. Split into two sequential steps with their own `env:` blocks:

| Step | Target | Secrets | Tags |
|---|---|---|---|
| Payment API | `PENTEST_BASE_URL` secret | `PENTEST_API_KEY`, `PENTEST_USER_TOKEN`, etc. | All except `destructive`, `stripe` |
| Stripe | `https://api.stripe.com` | `STRIPE_API_KEY`, `STRIPE_TEST_ACCOUNT_ID` | `stripe` only, except `destructive` |

Stripe step uses `if: always()` so it runs even if the Payment API step has failures. Both steps have `PENTEST_CREATE_ISSUES=true`.

### Fix 4 — Updated CLAUDE.md

Rewrote `CLAUDE.md` to reflect the current state of the project:
- Full project structure (spec/, generator/, report/ packages)
- Spec-driven test generation architecture
- Complete config reference (probe params, IDOR IDs, issue creation, Stripe keys)
- Updated running tests and JUnit tag tables
- Both nightly workflow steps documented
- Known findings tables for Payment API and Stripe

Added code review rules covering:
- **Security** — no secrets, no broad CORS, ownership checks in DB queries, session validation guards
- **Test quality** — new endpoints need tests, failing tests need explanation, probe params must use seeded IDs
- **CI/workflow** — issue creation stays opt-in, Stripe/Payment API steps stay separate, Surefire includes
- **Code style** — records over POJOs, switch expressions, no checked exceptions in test lambdas

## Setup required

Add to the `pentest-staging` GitHub environment before triggering the nightly workflow:

```bash
gh secret set STRIPE_API_KEY --env pentest-staging --body "sk_test_..."
gh secret set STRIPE_TEST_ACCOUNT_ID --env pentest-staging --body "cus_..."
```

## Files changed

| File | Change |
|---|---|
| `pom.xml` | Add `**/*Suite.java` to Surefire includes |
| `.github/workflows/nightly-pentest.yml` | Split into two test steps |
| `stripe/**/**.java` (7 files) | Add `@Tag("stripe")` to each class |
| `CLAUDE.md` | Full rewrite to reflect current project state + code review rules |

🤖 Generated with [Claude Code](https://claude.com/claude-code)