### PR TITLE
Add getInt helper to ConfigLoader

### DIFF
--- a/src/test/java/com/example/pentest/base/ConfigLoader.java
+++ b/src/test/java/com/example/pentest/base/ConfigLoader.java
@@ -50,6 +50,12 @@ public final class ConfigLoader {
         return value;
     }
 
+    public static int getInt(String key, int defaultValue) {
+        String value = get(key, null);
+        if (value == null) return defaultValue;
+        return Integer.parseInt(value);
+    }
+
     public static boolean isSandbox() {
         return "sandbox".equalsIgnoreCase(get("TARGET_ENV", "staging"));
     }


### PR DESCRIPTION
## Summary
- Adds a `getInt(String key, int defaultValue)` helper to `ConfigLoader` so callers can read integer config values (e.g. timeouts, retry counts) without parsing manually.

## Test plan
- [x] Verify `ConfigLoader.getInt("MISSING_KEY", 5)` returns `5`
- [x] Verify `ConfigLoader.getInt("PENTEST_TIMEOUT", 30)` returns the env var value when set

🤖 Generated with [Claude Code](https://claude.com/claude-code)