### PR TITLE
Add PaymentFinding class for structured pentest report output

### DIFF
--- a/src/test/java/com/example/pentest/report/PaymentFinding.java
+++ b/src/test/java/com/example/pentest/report/PaymentFinding.java
@@ -1,0 +1,55 @@
+package com.example.pentest.report;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents a single security finding from a pentest run.
+ */
+public class PaymentFinding {
+
+    private String endpoint;
+    private String severity;
+    private String description;
+    private List<String> evidence;
+
+    public PaymentFinding(String endpoint, String severity, String description) {
+        this.endpoint    = endpoint;
+        this.severity    = severity;
+        this.description = description;
+        this.evidence    = new ArrayList<>();
+    }
+
+    public String getEndpoint()               { return endpoint; }
+    public void   setEndpoint(String e)       { this.endpoint = e; }
+    public String getSeverity()               { return severity; }
+    public void   setSeverity(String s)       { this.severity = s; }
+    public String getDescription()            { return description; }
+    public void   setDescription(String d)    { this.description = d; }
+    public List<String> getEvidence()         { return evidence; }
+
+    public boolean isCritical() {
+        if (severity.equals("CRITICAL")) {
+            return true;
+        } else if (severity.equals("HIGH")) {
+            return true;
+        } else if (severity.equals("MEDIUM")) {
+            return false;
+        } else {
+            return false;
+        }
+    }
+
+    public void printSummary() {
+        System.out.println("[" + severity + "] " + endpoint);
+        System.out.println("  " + description);
+        System.out.println("  Evidence items: " + evidence.size());
+    }
+
+    public String formatForReport(int maxLength) {
+        String truncated = description.length() > maxLength
+            ? description.substring(0, maxLength) + "..."
+            : description;
+        return "[" + severity + "] " + endpoint + " — " + truncated;
+    }
+}


### PR DESCRIPTION
Introduces a `PaymentFinding` data class used by the report module to represent individual security findings before writing them to `summary.txt` or GitHub Issues.

## Changes
- `PaymentFinding.java` — fields: endpoint, severity, description, evidence list; includes `isCritical()` and `printSummary()` helpers